### PR TITLE
Fix session count showing incorrect values during rest period

### DIFF
--- a/Flyt/Managers/PomodoroManager.swift
+++ b/Flyt/Managers/PomodoroManager.swift
@@ -194,6 +194,8 @@ class PomodoroManager: ObservableObject {
             sessionCount += 1
             // セッション数を保存
             UserDefaults.standard.set(sessionCount, forKey: UserDefaultsKeys.sessionCount)
+            // タイムスタンプを更新（同期競合を防ぐため）
+            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastUpdated)
 
             // クラウドに同期
             SyncManager.shared.syncToCloud(sessionCount: sessionCount)


### PR DESCRIPTION
### Summary

Fixed issue where session count temporarily showed incorrect (old) values during rest period after work session completion.

### Changes

1. Added timestamp-based conflict resolution in `syncFromCloud()`
2. Update local timestamp when incrementing session count

### Root Cause

The `syncFromCloud()` method was overwriting local session count with stale cloud data due to race conditions in sync timing. Now we check timestamps and only apply cloud data if it's actually newer than local data.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)