### PR TITLE
fix: クラウドにデータがない場合にローカルセッション数を0にリセット

### DIFF
--- a/Flyt/Managers/SyncManager.swift
+++ b/Flyt/Managers/SyncManager.swift
@@ -137,7 +137,11 @@ class SyncManager: ObservableObject {
                     lastSyncStatus = .success
                 }
             } else {
-                lastSyncMessage = "クラウドにデータがありません"
+                // クラウドにデータがない場合、Server as Source of Truthの原則に従い
+                // ローカルのセッション数を0にリセット
+                onSessionCountUpdated?(0)
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastUpdated)
+                lastSyncMessage = "クラウドにデータがありません（ローカルを0にリセットしました）"
                 lastSyncStatus = .info
             }
 


### PR DESCRIPTION
### 概要

クラウド同期時、クラウドにデータがない場合（セッション数=0）はServer as Source of Truthの原則に従い、ローカルのセッション数も0にリセットするように修正。

### 変更内容

- `SyncManager.swift`: クラウドにデータがない場合に`onSessionCountUpdated?(0)`を呼び出してローカルをリセット
- ユーザーへのメッセージを改善

Fixes #17

Generated with [Claude Code](https://claude.ai/code)